### PR TITLE
Try grpc-node-server-reflection

### DIFF
--- a/node/dynamic_codegen/greeter_server.ts
+++ b/node/dynamic_codegen/greeter_server.ts
@@ -20,6 +20,7 @@ var PROTO_PATH = __dirname + '/../../protos/helloworld.proto';
 
 var grpc = require('@grpc/grpc-js');
 var protoLoader = require('@grpc/proto-loader');
+import wrapServerWithReflection from 'grpc-node-server-reflection';
 var packageDefinition = protoLoader.loadSync(
     PROTO_PATH,
     {keepCase: true,
@@ -42,7 +43,7 @@ function sayHello(call: any, callback: any) {
  * sample server port
  */
 function main() {
-  var server = new grpc.Server();
+  const server = wrapServerWithReflection(new grpc.Server());
   server.addService(hello_proto.Greeter.service, {sayHello: sayHello});
   server.bindAsync('0.0.0.0:50051', grpc.ServerCredentials.createInsecure(), () => {
     server.start();

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -363,6 +363,16 @@
       "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.17.3.tgz",
       "integrity": "sha512-OVPzcSWIAJ+d5yiHyeaLrdufQtrvaBrF4JQg+z8ynTkbO3uFcujqXszTumqg1cGsAsjkWnI+M5B1xZ19yR4Wyg=="
     },
+    "grpc-node-server-reflection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/grpc-node-server-reflection/-/grpc-node-server-reflection-1.0.2.tgz",
+      "integrity": "sha512-cHEHawsoL2HPZ8Q70i5vS8FU4yfFMDIVfHUU9iZehCjLrc4zb3LRVs5fGqQoJalefs46BAnICxYExkelXZG74w==",
+      "requires": {
+        "@grpc/grpc-js": "^1.2.8",
+        "@grpc/proto-loader": "^0.6.0-pre17",
+        "google-protobuf": "^3.15.1"
+      }
+    },
     "grpc-tools": {
       "version": "1.11.2",
       "resolved": "https://registry.npmjs.org/grpc-tools/-/grpc-tools-1.11.2.tgz",

--- a/node/package.json
+++ b/node/package.json
@@ -7,6 +7,7 @@
     "@tsconfig/node14": "^1.0.1",
     "async": "^3.2.0",
     "google-protobuf": "^3.17.3",
+    "grpc-node-server-reflection": "^1.0.2",
     "grpc-tools": "^1.11.2",
     "lodash": "^4.17.21",
     "minimist": "^1.2.0",

--- a/node/static_codegen/greeter_server.ts
+++ b/node/static_codegen/greeter_server.ts
@@ -20,7 +20,6 @@ import { HelloRequest, HelloReply } from "./pb/helloworld_pb";
 import { GreeterService } from "./pb/helloworld_grpc_pb";
 
 import * as grpc from "@grpc/grpc-js";
-import wrapServerWithReflection from 'grpc-node-server-reflection';
 
 /**
  * Implements the SayHello RPC method.
@@ -39,7 +38,7 @@ const sayHello: grpc.handleUnaryCall<HelloRequest, HelloReply> = (
  * sample server port
  */
 function main() {
-  const server = wrapServerWithReflection(new grpc.Server());
+  const server = new grpc.Server();
   server.addService(GreeterService, { sayHello: sayHello });
   server.bindAsync(
     "0.0.0.0:50051",

--- a/node/static_codegen/greeter_server.ts
+++ b/node/static_codegen/greeter_server.ts
@@ -20,6 +20,7 @@ import { HelloRequest, HelloReply } from "./pb/helloworld_pb";
 import { GreeterService } from "./pb/helloworld_grpc_pb";
 
 import * as grpc from "@grpc/grpc-js";
+import wrapServerWithReflection from 'grpc-node-server-reflection';
 
 /**
  * Implements the SayHello RPC method.
@@ -38,7 +39,7 @@ const sayHello: grpc.handleUnaryCall<HelloRequest, HelloReply> = (
  * sample server port
  */
 function main() {
-  var server = new grpc.Server();
+  const server = wrapServerWithReflection(new grpc.Server());
   server.addService(GreeterService, { sayHello: sayHello });
   server.bindAsync(
     "0.0.0.0:50051",


### PR DESCRIPTION
https://www.npmjs.com/package/grpc-node-server-reflection

Works well with dynamic_codegen:

```
[github.com/astj/node-grpc]$ grpcurl  -plaintext localhost:50051 describe helloworld.Greeter
helloworld.Greeter is a service:
service Greeter {
  rpc SayHello ( .helloworld.HelloRequest ) returns ( .helloworld.HelloReply );
}
```

But describe does not with static_codegen:

```
[github.com/astj/node-grpc]$ grpcurl  -plaintext localhost:50051 list # this works with both static and dynamic
grpc.reflection.v1alpha.ServerReflection
helloworld.Greeter
[github.com/astj/node-grpc]$ grpcurl  -plaintext localhost:50051 describe helloworld.Greeter
Failed to resolve symbol "helloworld.Greeter": rpc error: code = Internal desc = Cannot read property 'findIndex' of undefined
```